### PR TITLE
Node root field

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,42 @@ schema {
 }
 ```
 
+### Node root field
+
+For implementing the [Node root field](https://facebook.github.io/relay/graphql/objectidentification.htm#sec-Node-root-field)
+a convenience class is provided:
+
+
+#### Convert Type and ID to Global ID
+
+```php
+$nodeId = Node::toGlobalId('Ship', '1');
+```
+
+returns a global ID which can be passed to the node root:
+
+```
+U2hpcDox
+```
+
+#### Convert Global ID back to type and ID
+
+```php
+$node = Node::fromGlobalId('U2hpcDox');
+```
+
+returns an object which can be queried:
+
+```php
+$node->getType(); //Ship
+$node->getId(); //1
+```
+
+#### Node root resolver
+
+For an example of how to implement the node root resolver please check the [StarWarsConnectionTest.php](tests/Functional/StarWarsConnectionTest.php)
+
+
 ## Contributing
 
 Please read our [guidelines](.github/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ $node = Node::fromGlobalId('U2hpcDox');
 returns an object which can be queried:
 
 ```php
-$node->getType(); //Ship
-$node->getId(); //1
+$node->getType(); // Ship
+$node->getId(); // 1
 ```
 
 #### Node root resolver

--- a/src/Node.php
+++ b/src/Node.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Digia\GraphQL\Relay;
+
+class Node
+{
+    private $type;
+    private $id;
+
+    private function __construct(string $type, string $id)
+    {
+        $this->type = $type;
+        $this->id = $id;
+    }
+
+    public static function toGlobalId(string $type, string $id): string
+    {
+        return base64_encode("${type}:${id}");
+    }
+
+    public static function fromGlobalId(string $id): Node
+    {
+        $decoded = base64_decode($id, true);
+        if (!$decoded) {
+            throw new \InvalidArgumentException('ID must be a valid base 64 string');
+        }
+
+        $elements = explode(':', $decoded, 2);
+        if (\count($elements) !== 2) {
+            throw new \InvalidArgumentException('ID was not correctly formed');
+        }
+
+        return new self($elements[0], $elements[1]);
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Node.php
+++ b/src/Node.php
@@ -21,11 +21,12 @@ class Node
     public static function fromGlobalId(string $id): Node
     {
         $decoded = base64_decode($id, true);
+
         if (!$decoded) {
             throw new \InvalidArgumentException('ID must be a valid base 64 string');
         }
 
-        $elements = explode(':', $decoded, 2);
+        $elements = explode(':', $decoded);
         if (\count($elements) !== 2) {
             throw new \InvalidArgumentException('ID was not correctly formed');
         }

--- a/src/Node.php
+++ b/src/Node.php
@@ -4,20 +4,40 @@ namespace Digia\GraphQL\Relay;
 
 final class Node
 {
+    /**
+     * @var string
+     */
     private $type;
+
+    /**
+     * @var string
+     */
     private $id;
 
+    /**
+     * @param string $type
+     * @param string $id
+     */
     private function __construct(string $type, string $id)
     {
         $this->type = $type;
         $this->id = $id;
     }
 
+    /**
+     * @param string $type
+     * @param string $id
+     * @return string
+     */
     public static function toGlobalId(string $type, string $id): string
     {
-        return base64_encode("${type}:${id}");
+        return \base64_encode("${type}:${id}");
     }
 
+    /**
+     * @param string $id
+     * @return Node
+     */
     public static function fromGlobalId(string $id): Node
     {
         $decoded = base64_decode($id, true);
@@ -34,11 +54,17 @@ final class Node
         return new self($elements[0], $elements[1]);
     }
 
+    /**
+     * @return string
+     */
     public function getType(): string
     {
         return $this->type;
     }
 
+    /**
+     * @return string
+     */
     public function getId(): string
     {
         return $this->id;

--- a/src/Node.php
+++ b/src/Node.php
@@ -40,7 +40,7 @@ final class Node
      */
     public static function fromGlobalId(string $id): Node
     {
-        $decoded = base64_decode($id, true);
+        $decoded = \base64_decode($id, true);
 
         if (!$decoded) {
             throw new \InvalidArgumentException('ID must be a valid base 64 string');

--- a/src/Node.php
+++ b/src/Node.php
@@ -2,7 +2,7 @@
 
 namespace Digia\GraphQL\Relay;
 
-class Node
+final class Node
 {
     private $type;
     private $id;

--- a/tests/Functional/StarWarsConnectionTest.php
+++ b/tests/Functional/StarWarsConnectionTest.php
@@ -322,16 +322,16 @@ class StarWarsConnectionTest extends TestCase
     {
         $id = Node::toGlobalId('Faction', '1');
 
-        $query = '
+        $query = "
         query NodeQuery {
-          node(id: "' .$id .'") {
+          node(id: \"${id}\") {
             ... on Faction {
               id
               name
             }
           }
         }
-        ';
+        ";
 
         $expected = [
             'node' => [

--- a/tests/Functional/StarWarsConnectionTest.php
+++ b/tests/Functional/StarWarsConnectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Digia\GraphQL\Relay\Test\Functional;
 
+use Digia\GraphQL\Relay\Node;
 use Digia\GraphQL\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 use function Digia\GraphQL\graphql;
@@ -267,13 +268,38 @@ class StarWarsConnectionTest extends TestCase
         $this->assertQuery($expected, $query);
     }
 
+    public function testAllowsQueryingByNodeId(): void
+    {
+        $id = Node::toGlobalId('Ship', '1');
+
+        $query = '
+        query NodeQuery {
+          node(id: "' .$id .'") {
+            ... on Ship {
+              id
+              name
+            }
+          }
+        }
+        ';
+
+        $expected = [
+            'node' => [
+                'id' => '1',
+                'name' => 'X-Wing',
+            ],
+        ];
+
+        $this->assertQuery($expected, $query);
+    }
+
     private function assertQuery($expected, $query)
     {
         foreach ($this->schemas as $schema) {
             /** @noinspection PhpUnhandledExceptionInspection */
             $result = graphql($schema, $query);
 
-            $this->assertEquals(['data' => $expected], $result);
+            $this->assertSame(['data' => $expected], $result);
         }
     }
 }

--- a/tests/Functional/StarWarsConnectionTest.php
+++ b/tests/Functional/StarWarsConnectionTest.php
@@ -297,16 +297,16 @@ class StarWarsConnectionTest extends TestCase
     {
         $id = Node::toGlobalId('Ship', '1');
 
-        $query = '
+        $query = "
         query NodeQuery {
-          node(id: "' .$id .'") {
+          node(id: \"${id}\") {
             ... on Ship {
               id
               name
             }
           }
         }
-        ';
+        ";
 
         $expected = [
             'node' => [

--- a/tests/Functional/StarWarsConnectionTest.php
+++ b/tests/Functional/StarWarsConnectionTest.php
@@ -32,10 +32,11 @@ class StarWarsConnectionTest extends TestCase
         $query = '
         query RebelsShipsQuery {
           rebels {
-            name,
+            name
             ships(first: 1) {
               edges {
                 node {
+                  id
                   name
                 }
               }
@@ -51,6 +52,7 @@ class StarWarsConnectionTest extends TestCase
                     'edges' => [
                         [
                             'node' => [
+                                'id' => 'U2hpcDox',
                                 'name' => 'X-Wing'
                             ]
                         ]
@@ -69,11 +71,13 @@ class StarWarsConnectionTest extends TestCase
         $query = '
         query MoreRebelShipsQuery {
           rebels {
-            name,
+            id
+            name
             ships(first: 2) {
               edges {
-                cursor,
+                cursor
                 node {
+                  id
                   name
                 }
               }
@@ -84,18 +88,21 @@ class StarWarsConnectionTest extends TestCase
 
         $expected = [
             'rebels' => [
+                'id' => 'RmFjdGlvbjox',
                 'name'  => 'Alliance to Restore the Republic',
                 'ships' => [
                     'edges' => [
                         [
                             'cursor' => 'YXJyYXljb25uZWN0aW9uOjA=',
                             'node'   => [
+                                'id' => 'U2hpcDox',
                                 'name' => 'X-Wing'
                             ]
                         ],
                         [
                             'cursor' => 'YXJyYXljb25uZWN0aW9uOjE=',
                             'node'   => [
+                                'id' => 'U2hpcDoy',
                                 'name' => 'Y-Wing'
                             ]
                         ]
@@ -114,11 +121,13 @@ class StarWarsConnectionTest extends TestCase
         $query = '
         query EndOfRebelShipsQuery {
           rebels {
-            name,
+            id
+            name
             ships(first: 3 after: "YXJyYXljb25uZWN0aW9uOjE=") {
               edges {
-                cursor,
+                cursor
                 node {
+                  id
                   name
                 }
               }
@@ -129,24 +138,28 @@ class StarWarsConnectionTest extends TestCase
 
         $expected = [
             'rebels' => [
+                'id' => 'RmFjdGlvbjox',
                 'name'  => 'Alliance to Restore the Republic',
                 'ships' => [
                     'edges' => [
                         [
                             'cursor' => 'YXJyYXljb25uZWN0aW9uOjI=',
                             'node'   => [
+                                'id' => 'U2hpcDoz',
                                 'name' => 'A-Wing'
                             ]
                         ],
                         [
                             'cursor' => 'YXJyYXljb25uZWN0aW9uOjM=',
                             'node'   => [
+                                'id' => 'U2hpcDo0',
                                 'name' => 'Millenium Falcon'
                             ]
                         ],
                         [
                             'cursor' => 'YXJyYXljb25uZWN0aW9uOjQ=',
                             'node'   => [
+                                'id' => 'U2hpcDo1',
                                 'name' => 'Home One'
                             ]
                         ]
@@ -165,11 +178,13 @@ class StarWarsConnectionTest extends TestCase
         $query = '
         query RebelsQuery {
           rebels {
-            name,
+            id
+            name
             ships(first: 3 after: "YXJyYXljb25uZWN0aW9uOjQ=") {
               edges {
-                cursor,
+                cursor
                 node {
+                  id
                   name
                 }
               }
@@ -180,6 +195,7 @@ class StarWarsConnectionTest extends TestCase
 
         $expected = [
             'rebels' => [
+                'id' => 'RmFjdGlvbjox',
                 'name'  => 'Alliance to Restore the Republic',
                 'ships' => ['edges' => []]
             ]
@@ -195,10 +211,12 @@ class StarWarsConnectionTest extends TestCase
         $query = '
         query EndOfRebelShipsQuery {
           rebels {
-            name,
+            id
+            name
             originalShips: ships(first: 2) {
               edges {
                 node {
+                  id
                   name
                 }
               }
@@ -209,6 +227,7 @@ class StarWarsConnectionTest extends TestCase
             moreShips: ships(first: 3 after: "YXJyYXljb25uZWN0aW9uOjE=") {
               edges {
                 node {
+                  id
                   name
                 }
               }
@@ -222,16 +241,19 @@ class StarWarsConnectionTest extends TestCase
 
         $expected = [
             'rebels' => [
+                'id' => 'RmFjdGlvbjox',
                 'name'          => 'Alliance to Restore the Republic',
                 'originalShips' => [
                     'edges'    => [
                         [
                             'node' => [
+                                'id' => 'U2hpcDox',
                                 'name' => 'X-Wing'
                             ]
                         ],
                         [
                             'node' => [
+                                'id' => 'U2hpcDoy',
                                 'name' => 'Y-Wing'
                             ]
                         ]
@@ -244,16 +266,19 @@ class StarWarsConnectionTest extends TestCase
                     'edges'    => [
                         [
                             'node' => [
+                                'id' => 'U2hpcDoz',
                                 'name' => 'A-Wing'
                             ]
                         ],
                         [
                             'node' => [
+                                'id' => 'U2hpcDo0',
                                 'name' => 'Millenium Falcon'
                             ]
                         ],
                         [
                             'node' => [
+                                'id' => 'U2hpcDo1',
                                 'name' => 'Home One'
                             ]
                         ]
@@ -268,7 +293,7 @@ class StarWarsConnectionTest extends TestCase
         $this->assertQuery($expected, $query);
     }
 
-    public function testAllowsQueryingByNodeId(): void
+    public function testAllowsQueryingShipByNodeId(): void
     {
         $id = Node::toGlobalId('Ship', '1');
 
@@ -285,8 +310,33 @@ class StarWarsConnectionTest extends TestCase
 
         $expected = [
             'node' => [
-                'id' => '1',
+                'id' => $id,
                 'name' => 'X-Wing',
+            ],
+        ];
+
+        $this->assertQuery($expected, $query);
+    }
+
+    public function testAllowsQueryingFactionByNodeId(): void
+    {
+        $id = Node::toGlobalId('Faction', '1');
+
+        $query = '
+        query NodeQuery {
+          node(id: "' .$id .'") {
+            ... on Faction {
+              id
+              name
+            }
+          }
+        }
+        ';
+
+        $expected = [
+            'node' => [
+                'id' => $id,
+                'name' => 'Alliance to Restore the Republic',
             ],
         ];
 

--- a/tests/Functional/starWarsSchema.php
+++ b/tests/Functional/starWarsSchema.php
@@ -21,12 +21,6 @@ function getNodeId(string $type, $variable) {
 }
 
 function addType(string $type, $variable) {
-    if (\is_object($variable)) {
-        $variable->type = $type;
-
-        return $variable;
-    }
-
     if (\is_array($variable)) {
         $variable['type'] = $type;
 

--- a/tests/Functional/starWarsSchema.php
+++ b/tests/Functional/starWarsSchema.php
@@ -30,7 +30,7 @@ function addType(string $type, $variable) {
     throw new \RuntimeException('Unable to set a type on the variable');
 }
 
-function nodeResolver($root, $args)
+function nodeResolver($args)
 {
     $node = Node::fromGlobalId($args['id']);
 
@@ -66,7 +66,7 @@ function starWarsSchemaWithArrayConnection()
                 return empire();
             },
             'node' => function ($root, $args) {
-                return nodeResolver($root, $args);
+                return nodeResolver($args);
             }
         ],
         'Faction' => [
@@ -109,7 +109,7 @@ function starWarsSchemaWithStoreConnection()
                 return empire();
             },
             'node' => function ($root, $args) {
-                return nodeResolver($root, $args);
+                return nodeResolver($args);
             }
         ],
         'Faction' => [

--- a/tests/Functional/starWarsSchema.php
+++ b/tests/Functional/starWarsSchema.php
@@ -4,6 +4,7 @@ namespace Digia\GraphQL\Relay\Test\Functional;
 
 use Digia\GraphQL\Relay\ArrayConnectionBuilder;
 use Digia\GraphQL\Relay\ConnectionArguments;
+use Digia\GraphQL\Relay\Node;
 use Digia\GraphQL\Relay\StoreConnectionBuilder;
 use function Digia\GraphQL\buildSchema;
 
@@ -23,6 +24,17 @@ function starWarsSchemaWithArrayConnection()
             },
             'empire' => function () {
                 return empire();
+            },
+            'node' => function ($_, $args) {
+                $node = Node::fromGlobalId($args['id']);
+                switch ($node->getType()) {
+                    case 'Ship':
+                        return getShip($node->getId());
+                    case 'Faction':
+                        return getFaction($node->getId());
+                    default:
+                        throw new \RuntimeException('No node resolver for type: ' . $node->getType());
+                }
             }
         ],
         'Faction' => [
@@ -35,7 +47,7 @@ function starWarsSchemaWithArrayConnection()
 
                 return ArrayConnectionBuilder::fromArray($data, $arguments);
             }
-        ]
+        ],
     ]);
 }
 

--- a/tests/Unit/NodeTest.php
+++ b/tests/Unit/NodeTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+
+namespace Digia\GraphQL\Relay\Test\Unit;
+
+use Digia\GraphQL\Relay\Node;
+use PHPUnit\Framework\TestCase;
+
+class NodeTest extends TestCase
+{
+    public function testItConvertsToGlobalId(): void
+    {
+        $nodeId = Node::toGlobalId('Ship', '1');
+
+        $this->assertSame('U2hpcDox', $nodeId, 'Node ID did not match');
+    }
+
+    public function testItConvertsFromGlobalId(): void
+    {
+        $node = Node::fromGlobalId('U2hpcDox');
+
+        $this->assertSame('Ship', $node->getType(), 'Type did not match');
+        $this->assertSame('1', $node->getId(), 'Id did not match');
+    }
+
+    public function testThrowsExceptionIfNotValidBase64String(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('ID must be a valid base 64 string');
+
+        Node::fromGlobalId('🦄');
+    }
+
+    public function testThrowsExceptionIfBadlyFormatted(): void
+    {
+        $this->expectExceptionMessage(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('ID was not correctly formed');
+
+        $bad = base64_encode('Ship11111::::::::::');
+        Node::fromGlobalId($bad);
+    }
+}

--- a/tests/Unit/NodeTest.php
+++ b/tests/Unit/NodeTest.php
@@ -6,7 +6,7 @@ namespace Digia\GraphQL\Relay\Test\Unit;
 use Digia\GraphQL\Relay\Node;
 use PHPUnit\Framework\TestCase;
 
-class NodeTest extends TestCase
+final class NodeTest extends TestCase
 {
     public function testItConvertsToGlobalId(): void
     {

--- a/tests/Unit/NodeTest.php
+++ b/tests/Unit/NodeTest.php
@@ -1,5 +1,4 @@
-<?php declare(strict_types=1);
-
+<?php
 
 namespace Digia\GraphQL\Relay\Test\Unit;
 
@@ -8,14 +7,14 @@ use PHPUnit\Framework\TestCase;
 
 final class NodeTest extends TestCase
 {
-    public function testItConvertsToGlobalId(): void
+    public function testConvertsTypeAndIdToGlobalId(): void
     {
         $nodeId = Node::toGlobalId('Ship', '1');
 
         $this->assertSame('U2hpcDox', $nodeId, 'Node ID did not match');
     }
 
-    public function testItConvertsFromGlobalId(): void
+    public function testConvertsGlobalIdToTypeAndId(): void
     {
         $node = Node::fromGlobalId('U2hpcDox');
 
@@ -36,7 +35,7 @@ final class NodeTest extends TestCase
         $this->expectExceptionMessage(\InvalidArgumentException::class);
         $this->expectExceptionMessage('ID was not correctly formed');
 
-        $bad = base64_encode('Ship11111::::::::::');
+        $bad = \base64_encode('Ship11111::::::::::');
         Node::fromGlobalId($bad);
     }
 }


### PR DESCRIPTION
Adds tooling to assist implementation of Relay [Node root field](https://facebook.github.io/relay/graphql/objectidentification.htm#sec-Node-root-field)

Changes proposed in this pull request:
 * Add `Node` class for converting to/from NodeIds
 * Document how to implement the node root field

Fixes #5 